### PR TITLE
Fix: Make module compatible to nuxt-svg-loader

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -17,8 +17,7 @@ const setupResponsiveLoader = userOptions => config => {
       rule.test.test('.png') &&
       rule.test.test('.jpg') &&
       rule.test.test('.gif') &&
-      rule.test.test('.webp') &&
-      rule.test.test('.svg')
+      rule.test.test('.webp')
   )
 
   /* If the image loader rule has been removed or edited then we cannot continue.

--- a/lib/module.js
+++ b/lib/module.js
@@ -38,7 +38,7 @@ const setupResponsiveLoader = userOptions => config => {
 
   /* Update the loader so it's no longer respo∏nsible for png/jpg/webp files */
   if (existingImageLoader) {
-    existingImageLoader.test = /\.(svg|gif)$/i
+    existingImageLoader.test = existingImageLoader.test.test('.svg') ? /\.(svg|gif)$/i : /\.gif$/i
   }
 
   /* Add the new loader rule */

--- a/test/fixture/configs/svg.js
+++ b/test/fixture/configs/svg.js
@@ -6,15 +6,7 @@ module.exports = {
   render: {
     resourceHints: false
   },
-  modules: [
-    function () {
-      this.extendBuild(config => {
-        const rule = config.module.rules.find(rule => rule.test.test('.png'))
-        rule.test = /\.jpg$/i
-      })
-    },
-    '@@'
-  ],
+  modules: ['nuxt-svg-loader', '@@'],
   build: {
     filenames: {
       app: '[name].js',

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -122,3 +122,23 @@ describe('Error states', () => {
     await nuxt.close()
   })
 })
+
+describe('Svg compatibility', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    nuxt = new Nuxt(require('./fixture/configs/svg'))
+    await nuxt.ready()
+    const builder = new Builder(nuxt)
+    await builder.build()
+    const generator = new Generator(nuxt)
+    await generator.generate({ build: false })
+    await nuxt.close()
+  })
+
+  test('works', () => {})
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+})


### PR DESCRIPTION
Since this module is not directly related to SVG loading, this PR pre-checks the image rule if it contains an svg rule and acts accordingly.